### PR TITLE
Fix keypressed & keyreleased callbacks

### DIFF
--- a/lovr-keyboard.lua
+++ b/lovr-keyboard.lua
@@ -135,7 +135,8 @@ local keymap = {
 
 local reverse = {}
 for k, v in pairs(keymap) do
-  reverse[v] = k
+  local keycode = v[1]
+  reverse[keycode] = k
 end
 for k, v in pairs(reverse) do
   keymap[k] = v


### PR DESCRIPTION
Recent addition of `wasPressed` broke the keypressed and keyreleased callbacks.

Yeah, these callbacks are already in core LOVR; but if lovr-keyboard lib is used for key polling, then the internal implementation stops working .